### PR TITLE
fix fileComplete reference error in Loader.loadVideoTag

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -2640,7 +2640,7 @@ Phaser.Loader.prototype = {
             file.data.removeEventListener(file.loadEvent, videoLoadEvent, false);
             file.data.onerror = null;
             file.data.canplay = true;
-            _this.game.load.fileComplete(file);
+            _this.fileComplete(file);
         };
 
         file.data.onerror = function ()


### PR DESCRIPTION
This PR is a bug fix (closes #742)

Please include a summary in [Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md) and thank yourself.

Describe the changes below:
The game.load reference in the videoLoadEvent callback gets nulled when the game is destroyed. This uses the local reference for fileComplete instead.